### PR TITLE
Remove fivee from API Clients list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,6 @@
 ## Contents
 
 - [API Clients](#api-clients)
-  - [JS/TS](#jsts)
   - [Go](#go)
   - [Kotlin](#kotlin)
 - [Bots](#bots)

--- a/readme.md
+++ b/readme.md
@@ -22,10 +22,6 @@
 
 ## API Clients
 
-### JS/TS
-
-- [fergcb/fivee](https://github.com/fergcb/fivee) - Typescript wrapper library for the D&D 5e SRD API.
-
 ### Go
 
 API Clients written in go


### PR DESCRIPTION
I have deprecated and archived the Fivee TS/JS API wrapper, so am removing it from awesome-5e-srd.